### PR TITLE
Ahch-To:home of ProgPow Gangnam Testnet

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -138,6 +138,30 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     },
     gasPriceSettings: testnetDefaultGasPrice
   },
+  Gangnam: {
+    id: 'Gangnam',
+    name: 'Gangnam',
+    unit: 'ETH',
+    chainId: 43568,
+    isCustom: false,
+    color: '#adc101',
+    blockExplorer: makeExplorer({
+      name: 'Gangnam Explorer',
+      origin: 'https://explorer.progtest.net'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: ETH_TESTNET,
+      [SecureWalletName.LEDGER_NANO_S]: ETH_TESTNET,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ETH_TESTNET
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
+    }
+  },
   ETC: {
     id: 'ETC',
     name: 'Ethereum Classic',

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -65,6 +65,14 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       url: 'https://rinkeby.etherscan.io/api'
     }
   ],
+ Gangnam: [
+    {
+      name: makeNodeName('Gangnam', 'progtest'),
+      type: 'rpc',
+      service: 'Gangnam ProgPoW',
+      url: 'https://rpc.progtest.net'
+    }
+  ],
 
   ETC: [
     {

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -5,6 +5,7 @@ type StaticNetworkIds =
   | 'Ropsten'
   | 'Kovan'
   | 'Rinkeby'
+  | 'Gangnam'
   | 'ETC'
   | 'UBQ'
   | 'EXP'


### PR DESCRIPTION
Description

Adding Gangnam ProgPoW Testnet network

Ethstats: http://boot.gangnam.ethdevops.io/
Pool: https://testnet.progpool.pro/
Miner: { https://github.com/gangnamtestnet/progminer/releases,
https://github.com/hackmod/ethminer/releases }
Explorer: { https://explorer.progtest.net/ , https://gangnam.etherchain.org/ }
RPC : https://rpc.progtest.net/
Wallet (WIP): https://wallet.progtest.net/
Chainid: 43568
Node: https://gist.github.com/holiman/c8944c8be26f798e391822b9a70cb91c
Geth: https://github.com/gangnamtestnet/go-ethereum,
Parity: https://github.com/gangnamtestnet/parity-ethereum
Changes

Add additional testnet Gangnam